### PR TITLE
feat: use inline GitHub icon for source links

### DIFF
--- a/src/mdxify/source_links.py
+++ b/src/mdxify/source_links.py
@@ -1,6 +1,5 @@
 """Utilities for generating source code links."""
 
-import os
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -135,16 +134,14 @@ def add_source_link_to_header(
         link_text: Text for the link (default: "[source]")
     
     Returns:
-        Header with source link on the next line
+        Header with inline source link icon
     """
     if not source_link:
         return header
     
-    # Create a source link on a new line
-    # This prevents it from appearing in the sidebar navigation
-    # Using <sub> tag for smaller text which Mintlify supports
-    link_text_value = os.getenv("MDXIFY_SOURCE_LINK_TEXT", "view on GitHub ↗")
-    source_line = f'\n<sub>[{link_text_value}]({source_link})</sub>'
+    # Add GitHub icon inline with the header
+    # Using Mintlify's Icon component - let's see if it shows in nav
+    github_icon = f' <sup><a href="{source_link}"><Icon icon="github" size="14" /></a></sup>'
     
-    # Return header with source link on the next line
-    return f"{header}{source_line}"
+    # Return header with inline GitHub icon
+    return f"{header}{github_icon}"

--- a/tests/test_source_links.py
+++ b/tests/test_source_links.py
@@ -76,12 +76,12 @@ def test_add_source_link_to_header():
         "### `function_name`",
         "https://github.com/owner/repo/blob/main/module.py#L42",
     )
-    # The link should be on a new line with default text
-    expected = '### `function_name`\n<sub>[view on GitHub ↗](https://github.com/owner/repo/blob/main/module.py#L42)</sub>'
+    # The link should be inline with GitHub icon
+    expected = '### `function_name` <sup><a href="https://github.com/owner/repo/blob/main/module.py#L42"><Icon icon="github" size="14" /></a></sup>'
     assert result == expected
     
-    # Test that link is on new line
-    assert "### `function_name`\n<sub>" in result
+    # Test that link is inline
+    assert '<sup><a href="' in result
     
     # Test with no link
     result = add_source_link_to_header("### `function_name`", None)
@@ -89,30 +89,14 @@ def test_add_source_link_to_header():
 
 
 def test_add_source_link_with_custom_text(monkeypatch):
-    """Test source link with custom environment variable."""
-    # Test with custom text
+    """Test source link with icon (env var no longer used)."""
+    # The environment variable is no longer used since we use icon
+    # But let's test that it still works without errors
     monkeypatch.setenv("MDXIFY_SOURCE_LINK_TEXT", "[src]")
     result = add_source_link_to_header(
         "### `function_name`",
         "https://github.com/owner/repo/blob/main/module.py#L42",
     )
-    expected = '### `function_name`\n<sub>[[src]](https://github.com/owner/repo/blob/main/module.py#L42)</sub>'
-    assert result == expected
-    
-    # Test with emoji
-    monkeypatch.setenv("MDXIFY_SOURCE_LINK_TEXT", "🔗")
-    result = add_source_link_to_header(
-        "### `function_name`",
-        "https://github.com/owner/repo/blob/main/module.py#L42",
-    )
-    expected = '### `function_name`\n<sub>[🔗](https://github.com/owner/repo/blob/main/module.py#L42)</sub>'
-    assert result == expected
-    
-    # Test with custom unicode
-    monkeypatch.setenv("MDXIFY_SOURCE_LINK_TEXT", "⧉")
-    result = add_source_link_to_header(
-        "### `function_name`",
-        "https://github.com/owner/repo/blob/main/module.py#L42",
-    )
-    expected = '### `function_name`\n<sub>[⧉](https://github.com/owner/repo/blob/main/module.py#L42)</sub>'
+    # Should still produce the icon, not the custom text
+    expected = '### `function_name` <sup><a href="https://github.com/owner/repo/blob/main/module.py#L42"><Icon icon="github" size="14" /></a></sup>'
     assert result == expected


### PR DESCRIPTION
Changes source links from 'view on GitHub ↗' text on a new line to an inline GitHub icon. This keeps the documentation cleaner and prevents the arrow from appearing in Mintlify's right-hand navigation.