### PR TITLE
Add `--include-internal` flag to CLI

### DIFF
--- a/src/mdxify/_version.py
+++ b/src/mdxify/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.2.4.dev3+gb1daf4a.d20250620'
-__version_tuple__ = version_tuple = (0, 2, 4, 'dev3', 'gb1daf4a.d20250620')
+__version__ = version = '0.2.20.dev0+ge1e66fe.d20250716'
+__version_tuple__ = version_tuple = (0, 2, 20, 'dev0', 'ge1e66fe.d20250716')

--- a/src/mdxify/cli.py
+++ b/src/mdxify/cli.py
@@ -103,6 +103,12 @@ def main():
         default="main",
         help="Git branch name for source code links (default: main)",
     )
+    parser.add_argument(
+        "--include-internal",
+        action="store_true",
+        default=False,
+        help="Include internal modules in the documentation (default: False)",
+    )
 
     args = parser.parse_args()
 
@@ -181,7 +187,7 @@ def main():
         i, module_name = module_data
         
         # Skip internal modules
-        if not should_include_module(module_name):
+        if not should_include_module(module_name) and not args.include_internal:
             return (
                 f"[{i}/{len(modules_to_process)}] Skipping {module_name} (internal module)",
                 None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,3 +212,49 @@ def test_remove_excluded_files_helper(tmp_path):
     # Test with non-existent directory
     removed = remove_excluded_files(tmp_path / "nonexistent", ["anything"])
     assert removed == 0
+
+
+def test_include_internal():
+    """Test that --include-internal properly includes internal modules."""
+    with patch("mdxify.cli.find_all_modules") as mock_find, \
+         patch("mdxify.cli.get_module_source_file") as mock_source, \
+         patch("mdxify.cli.should_include_module") as mock_should_include, \
+         patch("mdxify.cli.parse_module_fast") as mock_parse, \
+         patch("mdxify.cli.generate_mdx") as mock_generate, \
+         patch.object(sys, "argv", [
+             "mdxify", "--all", "--root-module", "mypackage",
+             "--no-update-nav",
+             "--include-internal"
+         ]):
+        
+        # Setup mocks
+        mock_find.return_value = [
+            "mypackage",
+            "mypackage.core",
+            "mypackage.flows",
+            "mypackage.flows._private",
+        ]
+        mock_source.side_effect = lambda m: Path(f"{m.replace('.', '/')}.py")
+        mock_should_include.return_value = True
+        mock_parse.side_effect = lambda name, path: {
+            "name": name,
+            "docstring": f"Module {name}",
+            "functions": [],
+            "classes": []
+        }
+        
+        # Run
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        
+        assert exc_info.value.code == 0  # type: ignore
+        
+        # Check that all modules, including internal ones, were processed
+        processed_modules = [call[0][0]["name"] for call in mock_generate.call_args_list]
+        assert "mypackage" in processed_modules
+        assert "mypackage.core" in processed_modules
+        assert "mypackage.flows" in processed_modules
+        assert "mypackage.flows._private" in processed_modules
+        
+        # Should have processed 4 modules total
+        assert len(processed_modules) == 4


### PR DESCRIPTION
Allows users to optionally include internal/private modules in their generated docs.