### PR TITLE
fix: use CSS units for icon sizes to support Firefox

### DIFF
--- a/ADOPTION_GUIDE.md
+++ b/ADOPTION_GUIDE.md
@@ -134,3 +134,19 @@ docs/python-sdk/
 ├── mypackage-models-__init__.mdx
 └── mypackage-models-base.mdx
 ```
+
+## Local Mintlify Development
+
+If you're using Mintlify for documentation, you can preview locally:
+
+```bash
+cd docs && npx mint dev
+```
+
+Add these entries to your `.gitignore` for local Mintlify development:
+```
+# Mintlify local development
+docs/node_modules
+docs/package.json
+docs/package-lock.json
+```

--- a/src/mdxify/source_links.py
+++ b/src/mdxify/source_links.py
@@ -140,8 +140,8 @@ def add_source_link_to_header(
         return header
     
     # Add GitHub icon inline with the header
-    # Using Mintlify's Icon component - let's see if it shows in nav
-    github_icon = f' <sup><a href="{source_link}" target="_blank"><Icon icon="github" size="14" /></a></sup>'
+    # Using Mintlify's Icon component with proper CSS units for Firefox compatibility
+    github_icon = f' <sup><a href="{source_link}" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>'
     
     # Return header with inline GitHub icon
     return f"{header}{github_icon}"

--- a/tests/test_source_links.py
+++ b/tests/test_source_links.py
@@ -77,7 +77,7 @@ def test_add_source_link_to_header():
         "https://github.com/owner/repo/blob/main/module.py#L42",
     )
     # The link should be inline with GitHub icon
-    expected = '### `function_name` <sup><a href="https://github.com/owner/repo/blob/main/module.py#L42" target="_blank"><Icon icon="github" size="14" /></a></sup>'
+    expected = '### `function_name` <sup><a href="https://github.com/owner/repo/blob/main/module.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>'
     assert result == expected
     
     # Test that link is inline
@@ -98,5 +98,5 @@ def test_add_source_link_with_custom_text(monkeypatch):
         "https://github.com/owner/repo/blob/main/module.py#L42",
     )
     # Should still produce the icon, not the custom text
-    expected = '### `function_name` <sup><a href="https://github.com/owner/repo/blob/main/module.py#L42" target="_blank"><Icon icon="github" size="14" /></a></sup>'
+    expected = '### `function_name` <sup><a href="https://github.com/owner/repo/blob/main/module.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>'
     assert result == expected


### PR DESCRIPTION
## Summary
- Replace unit-less `size="14"` with `style="width: 14px; height: 14px;"` for Firefox compatibility
- Add local Mintlify development documentation

## Background
Firefox correctly rejects CSS with unit-less non-zero values per the CSS specification. This was reported in jlowin/fastmcp#1175 where generated MDX documentation icons weren't rendering properly in Firefox.

## Changes
1. Updated icon generation to use inline styles with proper CSS units
2. Added gitignore recommendations for local Mintlify development to ADOPTION_GUIDE.md
3. Updated tests to match new format

## Test plan
- [x] All tests pass
- [x] Pre-commit hooks pass
- [x] Generated MDX will now render correctly in Firefox

Thanks to @richardkmichael for reporting this issue\!

🤖 Generated with [Claude Code](https://claude.ai/code)