### PR TITLE
Fix: normalize line endings for consistent AST line numbers

### DIFF
--- a/src/mdxify/parser.py
+++ b/src/mdxify/parser.py
@@ -167,8 +167,11 @@ class ClassRegistry:
 def parse_module_fast(module_name: str, source_file: Path, include_internal: bool = False, 
                      class_registry: ClassRegistry | None = None) -> dict[str, Any]:
     """Parse a module quickly using AST."""
-    with open(source_file, "r", encoding="utf-8") as f:
+    with open(source_file, "r", encoding="utf-8", newline="") as f:
         source = f.read()
+    
+    # Normalize line endings to ensure consistent AST line numbers across platforms
+    source = source.replace("\r\n", "\n").replace("\r", "\n")
 
     tree = ast.parse(source)
 
@@ -244,8 +247,10 @@ def parse_modules_with_inheritance(modules_to_process: list[str], include_intern
         if not source_file:
             continue
         try:
-            with open(source_file, "r", encoding="utf-8") as f:
+            with open(source_file, "r", encoding="utf-8", newline="") as f:
                 source = f.read()
+            # Normalize line endings to ensure consistent AST line numbers across platforms
+            source = source.replace("\r\n", "\n").replace("\r", "\n")
             tree = ast.parse(source)
             for node in tree.body:
                 if isinstance(node, ast.ClassDef):


### PR DESCRIPTION
## Summary
- Normalizes line endings before AST parsing to ensure consistent line numbers across platforms
- Fixes off-by-one line number issues in generated documentation when running on different OS/environments

## Problem
FastMCP CI was failing because mdxify generated different line numbers locally vs in CI for the same source files. The root cause was inconsistent handling of line endings (CRLF vs LF) between environments.

## Solution
- Use `newline=""` when reading source files to prevent Python's automatic line ending conversion
- Explicitly normalize all line endings to LF before parsing with AST
- This ensures the AST parser sees identical content regardless of platform or git configuration

## Test plan
- [x] Tested on FastMCP repository - line numbers now match expected values
- [x] All existing tests pass
- [x] Verified fix works with TypedDict classes that were previously problematic