### PR TITLE
feat: add --version/-V flag to CLI

### DIFF
--- a/docs/mdxify-cli.mdx
+++ b/docs/mdxify-cli.mdx
@@ -10,7 +10,7 @@ CLI interface for mdxify.
 
 ## Functions
 
-### `remove_excluded_files` <sup><a href="https://github.com/zzstoatzz/mdxify/blob/main/src/mdxify/cli.py#L17" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `remove_excluded_files` <sup><a href="https://github.com/zzstoatzz/mdxify/blob/main/src/mdxify/cli.py#L18" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 remove_excluded_files(output_dir: Path, exclude_patterns: list[str]) -> int
@@ -22,7 +22,7 @@ Remove existing MDX files for excluded modules.
 Returns the number of files removed.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/mdxify/blob/main/src/mdxify/cli.py#L44" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/mdxify/blob/main/src/mdxify/cli.py#L45" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main()

--- a/src/mdxify/cli.py
+++ b/src/mdxify/cli.py
@@ -7,6 +7,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+from ._version import __version__
 from .discovery import find_all_modules, get_module_source_file, should_include_module
 from .generator import generate_mdx
 from .navigation import update_docs_json
@@ -44,6 +45,11 @@ def remove_excluded_files(output_dir: Path, exclude_patterns: list[str]) -> int:
 def main():
     parser = argparse.ArgumentParser(
         description="Generate API reference documentation for Python modules"
+    )
+    parser.add_argument(
+        "--version", "-V",
+        action="version",
+        version=f"mdxify {__version__}"
     )
     parser.add_argument(
         "modules",


### PR DESCRIPTION
## Summary
- Added `--version` and `-V` flags to show mdxify version
- Version is imported from the auto-generated `_version.py` file

## Test plan
- [x] Run `uvx mdxify --version` to see version output
- [x] Run `uvx mdxify -V` to see version output  
- [x] All existing tests pass

Fixes the issue where users couldn't check their installed mdxify version.