### PR TITLE
Stop generating empty module pages by default

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -151,3 +151,12 @@ uvx mdxify --all --root-module mypackage \
 | `--docs-json` | Path to docs.json file for navigation updates | `docs/docs.json` |
 | `--nav-output` | Write generated navigation to a standalone JSON file (skips docs.json update) | - |
 | `--anchor-name` | Name of the navigation group to update | `SDK Reference` |
+
+<Note>
+Modules with no documentable content (no docstring, functions, or classes) are
+skipped entirely — no page is generated and they're left out of the navigation.
+Any stub left by an earlier mdxify version is removed on the next run.
+
+The old `--skip-empty-parents` flag is deprecated and ignored; this is now the
+default behavior.
+</Note>

--- a/src/mdxify/cli.py
+++ b/src/mdxify/cli.py
@@ -5,6 +5,7 @@ import json
 import logging
 import sys
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock
@@ -166,7 +167,8 @@ def main():
         "--skip-empty-parents",
         action="store_true",
         default=False,
-        help="Skip parent modules that only contain boilerplate (default: False)",
+        help="Deprecated and ignored: empty modules are never generated. "
+        "Kept only so existing invocations don't break.",
     )
     parser.add_argument(
         "--anchor-name",
@@ -237,6 +239,17 @@ def main():
 
     # Show version banner for easier debugging and support requests
     print(f"mdxify version {__version__}")
+
+    if args.skip_empty_parents:
+        warnings.filterwarnings(
+            "always", category=DeprecationWarning, module=r"mdxify\.cli"
+        )
+        warnings.warn(
+            "--skip-empty-parents is deprecated and ignored; "
+            "empty modules are no longer generated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     # Configure logging based on verbosity
     if args.verbose:
@@ -472,7 +485,7 @@ def main():
                     output_file = args.output_dir / f"{module_name.replace('.', '-')}.{ext}"
 
                 file_existed = output_file.exists()
-                generate_mdx(
+                wrote = generate_mdx(
                     module_info,
                     output_file,
                     repo_url=repo_url,
@@ -482,6 +495,15 @@ def main():
                     docstring_style=docstring_style,
                     source_prefix=args.source_prefix,
                 )
+
+                if not wrote:
+                    # Empty module: no page generated (and any stale stub removed).
+                    msg = (
+                        f"[{i}/{len(modules_to_process)}] Skipping {module_name} (empty module)"
+                        if verbose
+                        else None
+                    )
+                    return (msg, None, None, "skipped", False)
 
                 module_time = time.time() - module_start
                 if verbose:

--- a/src/mdxify/generator.py
+++ b/src/mdxify/generator.py
@@ -29,7 +29,8 @@ def generate_mdx(
     renderer: Optional[Renderer] = None,
     docstring_style: str = "google",
     source_prefix: Optional[str] = None,
-) -> None:
+    skip_empty: bool = True,
+) -> bool:
     """Generate MDX documentation from module info.
 
     Args:
@@ -41,6 +42,12 @@ def generate_mdx(
         renderer: The renderer to use for output
         docstring_style: The docstring style to parse ("google", "numpy", or "sphinx")
         source_prefix: Optional prefix for source paths in monorepo layouts
+        skip_empty: When True (default), modules with no documentable content are
+            not written to disk (and any existing stub file is removed) instead of
+            producing an "empty module" placeholder page.
+
+    Returns:
+        True if a file was written for this module, False if it was skipped as empty.
     """
     if renderer is None:
         renderer = MDXRenderer()
@@ -67,21 +74,28 @@ def generate_mdx(
     )
 
     if not has_content:
+        if skip_empty:
+            # Don't generate a placeholder page for empty modules; remove any
+            # stub left behind by a previous run so it stops being served.
+            if output_file.exists():
+                output_file.unlink()
+            return False
+
         lines.append(
             "*This module is empty or contains only private/internal implementations.*"
         )
         lines.append("")
         output_file.parent.mkdir(parents=True, exist_ok=True)
         new_content = "\n".join(lines)
-        
+
         # Only write if content has changed
         if output_file.exists():
             existing_content = output_file.read_text()
             if existing_content == new_content:
-                return  # No changes needed
-        
+                return True  # No changes needed
+
         output_file.write_text(new_content)
-        return
+        return True
 
     if module_info["docstring"]:
         lines.append("")
@@ -200,6 +214,7 @@ def generate_mdx(
     if output_file.exists():
         existing_content = output_file.read_text()
         if existing_content == new_content:
-            return  # No changes needed
-    
+            return True  # No changes needed
+
     output_file.write_text(new_content)
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,3 +281,11 @@ def test_include_internal():
         
         # Should have processed 4 modules total
         assert len(processed_modules) == 4
+
+
+def test_skip_empty_parents_is_deprecated():
+    """--skip-empty-parents is accepted but emits a DeprecationWarning."""
+    with patch.object(sys, "argv", ["mdxify", "--skip-empty-parents", "nonexistent_pkg_xyz"]):
+        with pytest.warns(DeprecationWarning, match="--skip-empty-parents is deprecated"):
+            with pytest.raises(SystemExit):
+                main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -41,8 +41,8 @@ This module has content.
     assert is_module_empty(mdx_file) is False
 
 
-def test_generate_mdx_empty_module(tmp_path):
-    """Test generating MDX for an empty module."""
+def test_generate_mdx_empty_module_skipped_by_default(tmp_path):
+    """Empty modules are not written to disk by default."""
     module_info = {
         "name": "test.empty",
         "docstring": "",
@@ -50,10 +50,49 @@ def test_generate_mdx_empty_module(tmp_path):
         "classes": [],
         "source_file": "/path/to/file.py"
     }
-    
+
     output_file = tmp_path / "test-empty.mdx"
-    generate_mdx(module_info, output_file)
-    
+    wrote = generate_mdx(module_info, output_file)
+
+    assert wrote is False
+    assert not output_file.exists()
+
+
+def test_generate_mdx_empty_module_removes_existing_stub(tmp_path):
+    """A stub left by a previous run is removed when the module is empty."""
+    module_info = {
+        "name": "test.empty",
+        "docstring": "",
+        "functions": [],
+        "classes": [],
+        "source_file": "/path/to/file.py"
+    }
+
+    output_file = tmp_path / "test-empty.mdx"
+    output_file.write_text(
+        "*This module is empty or contains only private/internal implementations.*"
+    )
+
+    wrote = generate_mdx(module_info, output_file)
+
+    assert wrote is False
+    assert not output_file.exists()
+
+
+def test_generate_mdx_empty_module_opt_out(tmp_path):
+    """With skip_empty=False the placeholder page is still written."""
+    module_info = {
+        "name": "test.empty",
+        "docstring": "",
+        "functions": [],
+        "classes": [],
+        "source_file": "/path/to/file.py"
+    }
+
+    output_file = tmp_path / "test-empty.mdx"
+    wrote = generate_mdx(module_info, output_file, skip_empty=False)
+
+    assert wrote is True
     content = output_file.read_text()
     assert "title: empty" in content
     assert "*This module is empty or contains only private/internal implementations.*" in content


### PR DESCRIPTION
Empty modules no longer produce dead stub pages. Fixes the ~80 empty SDK reference pages Sean flagged (e.g. `prefect-cli-__init__`, which renders only *"This module is empty or contains only private/internal implementations."*).

<details>
<summary>What changed</summary>

- `generate_mdx` now skips writing a file for modules with no docstring/functions/classes by default, and deletes any stub left by a prior run. It returns a bool so the CLI keeps empty modules out of `generated_modules` — and therefore out of navigation. Empty parent pages already fall out of nav once their file is absent (`navigation.py:134`).
- `--skip-empty-parents` is **deprecated and ignored** (prints a warning when passed). It's kept so existing invocations don't break.
- Escape hatch: call `generate_mdx(..., skip_empty=False)` to restore the old placeholder page.

Regression tests cover: empty module not written, existing stub removed, and `skip_empty=False` opt-out.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)