### PR TITLE
fix: dead link for packages with only private submodules

### DIFF
--- a/src/mdxify/navigation.py
+++ b/src/mdxify/navigation.py
@@ -146,7 +146,18 @@ def build_hierarchical_navigation(
                 # This is a leaf module with no submodules
                 module_name = info["_path"]
                 filename = module_name.replace(".", "-")
-                
+
+                # A module whose only submodules are private/internal is rendered
+                # as a leaf here (its public children aren't in the tree), but the
+                # generator still wrote it as an "-__init__" page because the
+                # private submodules exist on disk. Point navigation at whichever
+                # file was actually written so we don't emit a dead link.
+                if (
+                    not (output_dir / f"{filename}.mdx").exists()
+                    and (output_dir / f"{filename}-__init__.mdx").exists()
+                ):
+                    filename = f"{filename}-__init__"
+
                 if nav_prefix:
                     nav_path = str(nav_prefix / filename).replace("\\", "/")
                 else:

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -496,3 +496,34 @@ def test_update_docs_json_with_tabs_structure(tmp_path):
     assert len(pages) == 2
     assert "python-sdk/fastmcp-client" in pages
     assert "python-sdk/fastmcp-server" in pages
+
+def test_leaf_module_points_to_init_file_when_only_private_submodules(tmp_path):
+    """A package whose only submodules are private is written as an -__init__
+    page; navigation must point at that file, not the bare leaf name.
+
+    Regression test for dead links like prefect-cli-deploy (nav) vs
+    prefect-cli-deploy-__init__.mdx (file on disk).
+    """
+    # The public module list only contains the package itself; its submodules
+    # are all private and therefore not generated.
+    modules = ["mypackage.cli.deploy"]
+
+    # On disk, the generator wrote the page with an -__init__ suffix.
+    (tmp_path / "mypackage-cli-deploy-__init__.mdx").write_text("# deploy")
+
+    result = build_hierarchical_navigation(modules, tmp_path, skip_empty_parents=False)
+
+    flat = json.dumps(result)
+    assert "mypackage-cli-deploy-__init__" in flat
+    # And not the bare (nonexistent) leaf path.
+    assert '"mypackage-cli-deploy"' not in flat
+
+
+def test_leaf_module_keeps_plain_name_when_file_present(tmp_path):
+    """A normal leaf whose plain file exists keeps the plain nav path."""
+    modules = ["mypackage.tasks"]
+    (tmp_path / "mypackage-tasks.mdx").write_text("# tasks")
+
+    result = build_hierarchical_navigation(modules, tmp_path, skip_empty_parents=False)
+    assert "mypackage-tasks" in json.dumps(result)
+    assert "mypackage-tasks-__init__" not in json.dumps(result)


### PR DESCRIPTION
Found while auditing Prefect's regenerated docs for dead links (follow-up to #42, #43).

A package whose only submodules are private (e.g. `prefect.cli.deploy`, whose children are all `_`-prefixed) is rendered as a **leaf** in the nav tree, but the generator writes it as a `…-__init__.mdx` page because those private submodules exist on disk. Navigation emitted the bare leaf path → 404.

The leaf branch now points at whichever file was actually written (prefers the plain page, falls back to `-__init__` when only that exists; falls back to the plain name when neither exists, preserving unit-test behavior).

Verified: regenerating Prefect's full SDK reference with this build yields **0 dead links and 0 orphans** across all 360 nav entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)