### PR TITLE
fix: escape curly braces in docstring prose (MDX JSX parse failures)

### DIFF
--- a/src/mdxify/formatter.py
+++ b/src/mdxify/formatter.py
@@ -6,11 +6,35 @@ import textwrap
 from griffe import Docstring
 
 # Pre-compile regex patterns for better performance
-_CODE_BLOCK_PATTERN = re.compile(r"(```[\s\S]*?```|`[^`]+`)")
+# Fenced blocks may span lines; inline code must NOT — MDX does not treat a
+# backtick span that wraps across a newline as code, so anything multi-line is
+# left to the prose escaper (otherwise braces inside it reach MDX unescaped and
+# are parsed as JSX expressions).
+_CODE_BLOCK_PATTERN = re.compile(r"(```[\s\S]*?```|`[^`\n]+`)")
 _TYPE_ANNOTATION_PATTERN = re.compile(
     r"\b(dict|list|tuple|set|type|Optional|Union|Callable|TypeVar|Generic|Literal|Any)\["
 )
 _ANGLE_BRACKET_PATTERN = re.compile(r"<([^>]+)>")
+
+
+def _escape_mdx_text(text: str) -> str:
+    """Escape a run of non-code text so MDX can't misparse it.
+
+    Handles type-annotation brackets, angle brackets, ``TODO:`` directives, and
+    curly braces. Curly braces are MDX expression delimiters, so an unescaped
+    ``{...}`` from a docstring (e.g. a dict example) is parsed as JSX and fails.
+    """
+    # Curly braces first: they're the highest-risk MDX characters. Escaping them
+    # before the other rules keeps later replacements from inserting literal
+    # braces that we'd then miss.
+    text = text.replace("{", "\\{").replace("}", "\\}")
+    # Escape square brackets in type annotations outside code blocks
+    text = _TYPE_ANNOTATION_PATTERN.sub(r"\1\\[", text)
+    # Replace angle brackets with HTML entities to prevent MDX from parsing as tags
+    text = _ANGLE_BRACKET_PATTERN.sub(r"&lt;\1&gt;", text)
+    # Escape TODO: which can be interpreted as MDX directive
+    text = text.replace("TODO:", "TODO\\:")
+    return text
 
 
 def format_docstring_with_griffe(docstring: str, style: str = "google") -> str:
@@ -124,12 +148,7 @@ def escape_mdx_content(content: str) -> str:
         # Add the text before the code block (escaped)
         text_before = content[last_end : match.start()]
         if text_before:
-            # Escape square brackets in type annotations outside code blocks
-            text_before = _TYPE_ANNOTATION_PATTERN.sub(r"\1\\[", text_before)
-            # Replace angle brackets with HTML entities to prevent MDX from parsing as tags
-            text_before = _ANGLE_BRACKET_PATTERN.sub(r"&lt;\1&gt;", text_before)
-            # Escape TODO: which can be interpreted as MDX directive
-            text_before = text_before.replace("TODO:", "TODO\\:")
+            text_before = _escape_mdx_text(text_before)
         parts.append(text_before)
 
         # Add the code block itself (unescaped)
@@ -140,11 +159,7 @@ def escape_mdx_content(content: str) -> str:
     # Add any remaining text after the last code block (escaped)
     remaining_text = content[last_end:]
     if remaining_text:
-        remaining_text = _TYPE_ANNOTATION_PATTERN.sub(r"\1\\[", remaining_text)
-        # Replace angle brackets with HTML entities to prevent MDX from parsing as tags
-        remaining_text = _ANGLE_BRACKET_PATTERN.sub(r"&lt;\1&gt;", remaining_text)
-        # Escape TODO: which can be interpreted as MDX directive
-        remaining_text = remaining_text.replace("TODO:", "TODO\\:")
+        remaining_text = _escape_mdx_text(remaining_text)
     parts.append(remaining_text)
 
     return "".join(parts)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -42,6 +42,43 @@ def test_escape_mdx_content_handles_todo():
     assert "TODO\\:" in result
 
 
+def test_escape_mdx_content_escapes_curly_braces():
+    """Curly braces outside code must be escaped so MDX doesn't parse them as JSX.
+
+    Regression test for docstrings containing dict examples like
+    {"python_params": ["a", "b"]}, which broke Mintlify's MDX parser.
+    """
+    content = 'For example {"python_params": ["john doe", "35"]} cannot exceed.'
+    result = escape_mdx_content(content)
+    assert "\\{" in result
+    assert "\\}" in result
+    # No bare brace should remain (which MDX would treat as an expression).
+    assert "{" not in result.replace("\\{", "")
+    assert "}" not in result.replace("\\}", "")
+
+
+def test_escape_mdx_content_preserves_braces_in_code():
+    """Braces inside inline code / code fences must be left untouched."""
+    content = 'Use `{"a": 1}` inline.\n\n```python\nd = {"a": 1}\n```\n'
+    result = escape_mdx_content(content)
+    assert '`{"a": 1}`' in result
+    assert 'd = {"a": 1}' in result
+    assert "\\{" not in result
+
+
+def test_escape_mdx_content_escapes_braces_in_multiline_inline_span():
+    """A backtick span that wraps across a newline is NOT inline code in MDX, so
+    its braces must still be escaped (otherwise MDX parses them as JSX).
+
+    Regression test for prefect_databricks-jobs.mdx, which failed Mintlify's
+    parser with "Could not parse expression".
+    """
+    content = "for example `'sql_params'\\:\n{'name'\\: 'john doe'}`. The task"
+    result = escape_mdx_content(content)
+    assert "\\{" in result
+    assert "\\}" in result
+
+
 def test_format_docstring_with_griffe_simple():
     """Test formatting a simple docstring."""
     docstring = """


### PR DESCRIPTION
Found while regenerating Prefect's integration docs — Mintlify's MDX parser (`mint broken-links`) failed on generated files with *"Unable to parse … expression in container"*.

Two related causes, both fixed here:

1. **Bare `{...}` in docstring prose** (e.g. a dict example like `{"python_params": [...]}`) was emitted unescaped. MDX treats `{` as a JSX expression delimiter. `escape_mdx_content` now escapes `{`/`}` → `\{`/`\}` outside code.
2. **Multi-line backtick spans** were matched as inline code by the escaper, but MDX does *not* treat a backtick span wrapping across a newline as code — so braces inside still reached the parser. Inline code is now matched single-line only; multi-line content falls through to prose escaping.

Verified: regenerating Prefect's full integration docs and running `npx mint broken-links` → **"success no broken links found"** (previously hard-failed). Regression tests added for all three cases (prose braces, braces preserved in real code, braces in a multi-line span).

🤖 Generated with [Claude Code](https://claude.com/claude-code)