### PR TITLE
fix: track code fences line-by-line in MDX escaper

### DIFF
--- a/src/mdxify/formatter.py
+++ b/src/mdxify/formatter.py
@@ -6,11 +6,12 @@ import textwrap
 from griffe import Docstring
 
 # Pre-compile regex patterns for better performance
-# Fenced blocks may span lines; inline code must NOT — MDX does not treat a
-# backtick span that wraps across a newline as code, so anything multi-line is
-# left to the prose escaper (otherwise braces inside it reach MDX unescaped and
-# are parsed as JSX expressions).
-_CODE_BLOCK_PATTERN = re.compile(r"(```[\s\S]*?```|`[^`\n]+`)")
+# A fence is ``` (optionally indented, optionally with a language) on its own line.
+_FENCE_PATTERN = re.compile(r"^\s*```")
+# Inline code spans a single line only — MDX does not treat a backtick span that
+# wraps across a newline as code, so multi-line backtick content is left to the
+# prose escaper (otherwise braces inside it reach MDX unescaped and parse as JSX).
+_INLINE_CODE_PATTERN = re.compile(r"`[^`\n]+`")
 _TYPE_ANNOTATION_PATTERN = re.compile(
     r"\b(dict|list|tuple|set|type|Optional|Union|Callable|TypeVar|Generic|Literal|Any)\["
 )
@@ -136,30 +137,40 @@ def format_docstring_with_griffe(docstring: str, style: str = "google") -> str:
         return docstring
 
 
-def escape_mdx_content(content: str) -> str:
-    """Escape content for MDX to prevent parsing issues, but not inside code blocks."""
-    # Split content by code blocks to avoid escaping inside them
-    # Pattern matches both inline code (`...`) and code blocks (```...```)
+def _escape_line_outside_code(line: str) -> str:
+    """Escape a single non-fenced line, leaving single-line inline code spans alone."""
     parts = []
     last_end = 0
-
-    # Find all code blocks and inline code
-    for match in _CODE_BLOCK_PATTERN.finditer(content):
-        # Add the text before the code block (escaped)
-        text_before = content[last_end : match.start()]
-        if text_before:
-            text_before = _escape_mdx_text(text_before)
-        parts.append(text_before)
-
-        # Add the code block itself (unescaped)
-        parts.append(match.group(0))
-
+    for match in _INLINE_CODE_PATTERN.finditer(line):
+        prose = line[last_end : match.start()]
+        if prose:
+            parts.append(_escape_mdx_text(prose))
+        parts.append(match.group(0))  # inline code, verbatim
         last_end = match.end()
-
-    # Add any remaining text after the last code block (escaped)
-    remaining_text = content[last_end:]
-    if remaining_text:
-        remaining_text = _escape_mdx_text(remaining_text)
-    parts.append(remaining_text)
-
+    tail = line[last_end:]
+    if tail:
+        parts.append(_escape_mdx_text(tail))
     return "".join(parts)
+
+
+def escape_mdx_content(content: str) -> str:
+    """Escape content for MDX to prevent parsing issues, but not inside code.
+
+    Scans line by line so fenced code blocks (```` ``` ````) are tracked with a
+    simple state machine. This mirrors how MDX/CommonMark parse fences — including
+    auto-closing an unterminated fence at end of input — so braces and other
+    MDX-special characters inside code are never escaped, while everything in
+    prose is. A regex over the whole string can't do this reliably when fences
+    are unbalanced (which Griffe's Examples sections sometimes produce).
+    """
+    out = []
+    in_fence = False
+    for line in content.split("\n"):
+        if _FENCE_PATTERN.match(line):
+            in_fence = not in_fence
+            out.append(line)
+        elif in_fence:
+            out.append(line)
+        else:
+            out.append(_escape_line_outside_code(line))
+    return "\n".join(out)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -66,6 +66,19 @@ def test_escape_mdx_content_preserves_braces_in_code():
     assert "\\{" not in result
 
 
+def test_escape_mdx_content_unterminated_fence_keeps_code_unescaped():
+    """An unterminated ```python fence (as Griffe Examples sometimes emit) must
+    still be treated as code through end of input — braces left untouched.
+
+    Regression test for prefect-flows.mdx, where `print(f"hello {name}")` inside
+    an unclosed example fence was being escaped to `\\{name\\}`.
+    """
+    content = 'Example:\n\n```python\n@flow\ndef my_flow(name):\n    print(f"hello {name}")\n'
+    result = escape_mdx_content(content)
+    assert 'print(f"hello {name}")' in result
+    assert "\\{name\\}" not in result
+
+
 def test_escape_mdx_content_escapes_braces_in_multiline_inline_span():
     """A backtick span that wraps across a newline is NOT inline code in MDX, so
     its braces must still be escaped (otherwise MDX parses them as JSX).


### PR DESCRIPTION
Follow-up to #45. The regex-based escaper there fixed the hard MDX parse failures but introduced a cosmetic regression: docstrings with an **unterminated** ```python example fence (which Griffe's Examples sections sometimes emit) had braces inside the code escaped — `print(f"hello {name}")` became `print(f"hello \{name\}")`.

MDX auto-closes an unterminated fence at end of input; the regex required a closing fence, so it misclassified the trailing code as prose. Replaced with a line-based scanner that toggles fence state on ``` lines (mirroring CommonMark/MDX), escaping only non-fenced lines. Inline code is still matched single-line so multi-line backtick spans fall through to prose escaping.

Verified against Prefect's core + integration docs: `mint broken-links` clean, and code examples keep their literal braces. Regression test added for the unterminated-fence case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)