### PR TITLE
revert: drop curly-brace escaping whack-a-mole

### DIFF
--- a/src/mdxify/formatter.py
+++ b/src/mdxify/formatter.py
@@ -6,36 +6,11 @@ import textwrap
 from griffe import Docstring
 
 # Pre-compile regex patterns for better performance
-# A fence is ``` (optionally indented, optionally with a language) on its own line.
-_FENCE_PATTERN = re.compile(r"^\s*```")
-# Inline code spans a single line only — MDX does not treat a backtick span that
-# wraps across a newline as code, so multi-line backtick content is left to the
-# prose escaper (otherwise braces inside it reach MDX unescaped and parse as JSX).
-_INLINE_CODE_PATTERN = re.compile(r"`[^`\n]+`")
+_CODE_BLOCK_PATTERN = re.compile(r"(```[\s\S]*?```|`[^`]+`)")
 _TYPE_ANNOTATION_PATTERN = re.compile(
     r"\b(dict|list|tuple|set|type|Optional|Union|Callable|TypeVar|Generic|Literal|Any)\["
 )
 _ANGLE_BRACKET_PATTERN = re.compile(r"<([^>]+)>")
-
-
-def _escape_mdx_text(text: str) -> str:
-    """Escape a run of non-code text so MDX can't misparse it.
-
-    Handles type-annotation brackets, angle brackets, ``TODO:`` directives, and
-    curly braces. Curly braces are MDX expression delimiters, so an unescaped
-    ``{...}`` from a docstring (e.g. a dict example) is parsed as JSX and fails.
-    """
-    # Curly braces first: they're the highest-risk MDX characters. Escaping them
-    # before the other rules keeps later replacements from inserting literal
-    # braces that we'd then miss.
-    text = text.replace("{", "\\{").replace("}", "\\}")
-    # Escape square brackets in type annotations outside code blocks
-    text = _TYPE_ANNOTATION_PATTERN.sub(r"\1\\[", text)
-    # Replace angle brackets with HTML entities to prevent MDX from parsing as tags
-    text = _ANGLE_BRACKET_PATTERN.sub(r"&lt;\1&gt;", text)
-    # Escape TODO: which can be interpreted as MDX directive
-    text = text.replace("TODO:", "TODO\\:")
-    return text
 
 
 def format_docstring_with_griffe(docstring: str, style: str = "google") -> str:
@@ -137,40 +112,39 @@ def format_docstring_with_griffe(docstring: str, style: str = "google") -> str:
         return docstring
 
 
-def _escape_line_outside_code(line: str) -> str:
-    """Escape a single non-fenced line, leaving single-line inline code spans alone."""
+def escape_mdx_content(content: str) -> str:
+    """Escape content for MDX to prevent parsing issues, but not inside code blocks."""
+    # Split content by code blocks to avoid escaping inside them
+    # Pattern matches both inline code (`...`) and code blocks (```...```)
     parts = []
     last_end = 0
-    for match in _INLINE_CODE_PATTERN.finditer(line):
-        prose = line[last_end : match.start()]
-        if prose:
-            parts.append(_escape_mdx_text(prose))
-        parts.append(match.group(0))  # inline code, verbatim
+
+    # Find all code blocks and inline code
+    for match in _CODE_BLOCK_PATTERN.finditer(content):
+        # Add the text before the code block (escaped)
+        text_before = content[last_end : match.start()]
+        if text_before:
+            # Escape square brackets in type annotations outside code blocks
+            text_before = _TYPE_ANNOTATION_PATTERN.sub(r"\1\\[", text_before)
+            # Replace angle brackets with HTML entities to prevent MDX from parsing as tags
+            text_before = _ANGLE_BRACKET_PATTERN.sub(r"&lt;\1&gt;", text_before)
+            # Escape TODO: which can be interpreted as MDX directive
+            text_before = text_before.replace("TODO:", "TODO\\:")
+        parts.append(text_before)
+
+        # Add the code block itself (unescaped)
+        parts.append(match.group(0))
+
         last_end = match.end()
-    tail = line[last_end:]
-    if tail:
-        parts.append(_escape_mdx_text(tail))
+
+    # Add any remaining text after the last code block (escaped)
+    remaining_text = content[last_end:]
+    if remaining_text:
+        remaining_text = _TYPE_ANNOTATION_PATTERN.sub(r"\1\\[", remaining_text)
+        # Replace angle brackets with HTML entities to prevent MDX from parsing as tags
+        remaining_text = _ANGLE_BRACKET_PATTERN.sub(r"&lt;\1&gt;", remaining_text)
+        # Escape TODO: which can be interpreted as MDX directive
+        remaining_text = remaining_text.replace("TODO:", "TODO\\:")
+    parts.append(remaining_text)
+
     return "".join(parts)
-
-
-def escape_mdx_content(content: str) -> str:
-    """Escape content for MDX to prevent parsing issues, but not inside code.
-
-    Scans line by line so fenced code blocks (```` ``` ````) are tracked with a
-    simple state machine. This mirrors how MDX/CommonMark parse fences — including
-    auto-closing an unterminated fence at end of input — so braces and other
-    MDX-special characters inside code are never escaped, while everything in
-    prose is. A regex over the whole string can't do this reliably when fences
-    are unbalanced (which Griffe's Examples sections sometimes produce).
-    """
-    out = []
-    in_fence = False
-    for line in content.split("\n"):
-        if _FENCE_PATTERN.match(line):
-            in_fence = not in_fence
-            out.append(line)
-        elif in_fence:
-            out.append(line)
-        else:
-            out.append(_escape_line_outside_code(line))
-    return "\n".join(out)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -42,56 +42,6 @@ def test_escape_mdx_content_handles_todo():
     assert "TODO\\:" in result
 
 
-def test_escape_mdx_content_escapes_curly_braces():
-    """Curly braces outside code must be escaped so MDX doesn't parse them as JSX.
-
-    Regression test for docstrings containing dict examples like
-    {"python_params": ["a", "b"]}, which broke Mintlify's MDX parser.
-    """
-    content = 'For example {"python_params": ["john doe", "35"]} cannot exceed.'
-    result = escape_mdx_content(content)
-    assert "\\{" in result
-    assert "\\}" in result
-    # No bare brace should remain (which MDX would treat as an expression).
-    assert "{" not in result.replace("\\{", "")
-    assert "}" not in result.replace("\\}", "")
-
-
-def test_escape_mdx_content_preserves_braces_in_code():
-    """Braces inside inline code / code fences must be left untouched."""
-    content = 'Use `{"a": 1}` inline.\n\n```python\nd = {"a": 1}\n```\n'
-    result = escape_mdx_content(content)
-    assert '`{"a": 1}`' in result
-    assert 'd = {"a": 1}' in result
-    assert "\\{" not in result
-
-
-def test_escape_mdx_content_unterminated_fence_keeps_code_unescaped():
-    """An unterminated ```python fence (as Griffe Examples sometimes emit) must
-    still be treated as code through end of input — braces left untouched.
-
-    Regression test for prefect-flows.mdx, where `print(f"hello {name}")` inside
-    an unclosed example fence was being escaped to `\\{name\\}`.
-    """
-    content = 'Example:\n\n```python\n@flow\ndef my_flow(name):\n    print(f"hello {name}")\n'
-    result = escape_mdx_content(content)
-    assert 'print(f"hello {name}")' in result
-    assert "\\{name\\}" not in result
-
-
-def test_escape_mdx_content_escapes_braces_in_multiline_inline_span():
-    """A backtick span that wraps across a newline is NOT inline code in MDX, so
-    its braces must still be escaped (otherwise MDX parses them as JSX).
-
-    Regression test for prefect_databricks-jobs.mdx, which failed Mintlify's
-    parser with "Could not parse expression".
-    """
-    content = "for example `'sql_params'\\:\n{'name'\\: 'john doe'}`. The task"
-    result = escape_mdx_content(content)
-    assert "\\{" in result
-    assert "\\}" in result
-
-
 def test_format_docstring_with_griffe_simple():
     """Test formatting a simple docstring."""
     docstring = """


### PR DESCRIPTION
Reverts the brace-escaping from #45/#46. It degraded output (backtick inline code → backslash-escaped braces) and was the wrong layer. Empty-module/nav fixes (0.2.40–0.2.42) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)